### PR TITLE
Hide unaligned loads/stores behind an BSC_ALLOW_UNALIGNED

### DIFF
--- a/libbsc/coder/coder.cpp
+++ b/libbsc/coder/coder.cpp
@@ -139,8 +139,13 @@ int bsc_coder_compress_serial(const unsigned char * input, unsigned char * outpu
             result = inputSize; memcpy(output + outputPtr, input + inputStart, inputSize);
         }
 
+#if defined(BSC_ALLOW_UNALIGNED)
         *(int *)(output + 1 + 8 * blockId + 0) = inputSize;
         *(int *)(output + 1 + 8 * blockId + 4) = result;
+#else
+        memcpy(output + 1 + 8 * blockId + 0, &inputSize, sizeof(int));
+        memcpy(output + 1 + 8 * blockId + 4, &result, sizeof(int));
+#endif
 
         outputPtr += result;
     }

--- a/libbsc/coder/common/rangecoder.h
+++ b/libbsc/coder/common/rangecoder.h
@@ -62,12 +62,22 @@ private:
 
     INLINE void OutputShort(unsigned short s)
     {
+#if defined(BSC_ALLOW_UNALIGNED)
         *ari_output++ = s;
+#else
+        memcpy(ari_output++, &s, sizeof(unsigned short));
+#endif
     };
 
     INLINE unsigned short InputShort()
     {
+#if defined(BSC_ALLOW_UNALIGNED)
         return *ari_input++;
+#else
+        unsigned short ret;
+        memcpy(&ret, ari_input++, sizeof(unsigned short));
+        return ret;
+#endif
     };
 
     INLINE void ShiftLow()


### PR DESCRIPTION
Unaligned access are undefined behavior.  Allowing them can result in
small performance improvements, but can also cause crashes.  Even on
platforms with generally allow unaligned access (such as x86), not all
instructions do (such as certain vector instructions).  This means that
future compiler optimizations can (and do) cause code which previously
worked stop functioning.  Additionally, older hardware implementing the
same instruction set may not allow unaligned access even if newer
hardware does.

You should only allow unaligned access if your application is extremely
performance sensitive, and even then only after thoroughly testing the
configuration (including the exact compiler version and compilation
flags) on the hardware that you will be using.